### PR TITLE
Scancode enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Originaly from:
  * Written by Chris J. Kiick, January 2008. https://github.com/ckiick
  * modified by Gene E. Scogin, August 2008.
  * modified by Tomas 'Harvie' Mudrunka 2019. https://github.com/harvie/ps2dev
+ * modified once more by Iggy Glassman 2020. https://github.com/iggyglass
  * Release into public domain.
 
 Further reading:

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -9,35 +9,35 @@
 
 #include "ps2dev.h"
 
-//Enable serial debug mode?
+// Enable serial debug mode?
 //#define _PS2DBG Serial
 
-//since for the device side we are going to be in charge of the clock,
-//the two defines below are how long each _phase_ of the clock cycle is
+// since for the device side we are going to be in charge of the clock,
+// the two defines below are how long each _phase_ of the clock cycle is
 #define CLKFULL 40
+
 // we make changes in the middle of a phase, this how long from the
 // start of phase to the when we drive the data line
 #define CLKHALF 20
 
 // Delay between bytes
-// I've found i need at least 400us to get this working at all,
-// but even more is needed for reliability, so i've put 1000us
+// I've found I need at least 400us to get this working at all,
+// but even more is needed for reliability, so I've put 1000us
 #define BYTEWAIT 1000
 
 // Timeout if computer not sending for 30ms
 #define TIMEOUT 30
 
-
 /*
  * the clock and data pins can be wired directly to the clk and data pins
- * of the PS2 connector.  No external parts are needed.
+ * of the PS2 connector. No external parts are needed.
  */
 PS2dev::PS2dev(int clk, int data)
 {
-  _ps2clk = clk;
-  _ps2data = data;
-  gohi(_ps2clk);
-  gohi(_ps2data);
+	_ps2clk = clk;
+	_ps2data = data;
+	gohi(_ps2clk);
+	gohi(_ps2data);
 }
 
 /*
@@ -46,270 +46,253 @@ PS2dev::PS2dev(int clk, int data)
  * various conditions.  It's done this way so you don't need
  * pullup resistors.
  */
-void
-PS2dev::gohi(int pin)
+void PS2dev::gohi(int pin)
 {
-  pinMode(pin, INPUT);
-  digitalWrite(pin, HIGH);
+	pinMode(pin, INPUT);
+	digitalWrite(pin, HIGH);
 }
 
-void
-PS2dev::golo(int pin)
+void PS2dev::golo(int pin)
 {
-  digitalWrite(pin, LOW);
-  pinMode(pin, OUTPUT);
+	digitalWrite(pin, LOW);
+	pinMode(pin, OUTPUT);
 }
 
 int PS2dev::write(unsigned char data)
 {
-  delayMicroseconds(BYTEWAIT);
+	delayMicroseconds(BYTEWAIT);
 
-  unsigned char i;
-  unsigned char parity = 1;
+	unsigned char i;
+	unsigned char parity = 1;
 
 #ifdef _PS2DBG
-  _PS2DBG.print(F("sending "));
-  _PS2DBG.println(data,HEX);
+	_PS2DBG.print(F("sending "));
+	_PS2DBG.println(data,HEX);
 #endif
 
-  if (digitalRead(_ps2clk) == LOW) {
-    return -1;
-  }
+	if (digitalRead(_ps2clk) == LOW) return -1;
 
-  if (digitalRead(_ps2data) == LOW) {
-    return -2;
-  }
+	if (digitalRead(_ps2data) == LOW) return -2;
 
-  golo(_ps2data);
-  delayMicroseconds(CLKHALF);
-  // device sends on falling clock
-  golo(_ps2clk);	// start bit
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
+	golo(_ps2data);
+	delayMicroseconds(CLKHALF);
 
-  for (i=0; i < 8; i++)
+	// device sends on falling clock
+	golo(_ps2clk);	// start bit
+	delayMicroseconds(CLKFULL);
+	gohi(_ps2clk);
+	delayMicroseconds(CLKHALF);
+
+	for (i = 0; i < 8; i++)
     {
-      if (data & 0x01)
-      {
-        gohi(_ps2data);
-      } else {
-        golo(_ps2data);
-      }
-      delayMicroseconds(CLKHALF);
-      golo(_ps2clk);
-      delayMicroseconds(CLKFULL);
-      gohi(_ps2clk);
-      delayMicroseconds(CLKHALF);
+    	if (data & 0x01) gohi(_ps2data);
+		else golo(_ps2data);
 
-      parity = parity ^ (data & 0x01);
-      data = data >> 1;
+    	delayMicroseconds(CLKHALF);
+    	golo(_ps2clk);
+    	delayMicroseconds(CLKFULL);
+    	gohi(_ps2clk);
+    	delayMicroseconds(CLKHALF);
+
+    	parity = parity ^ (data & 0x01);
+    	data = data >> 1;
     }
-  // parity bit
-  if (parity)
-  {
-    gohi(_ps2data);
-  } else {
-    golo(_ps2data);
-  }
-  delayMicroseconds(CLKHALF);
-  golo(_ps2clk);
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
 
-  // stop bit
-  gohi(_ps2data);
-  delayMicroseconds(CLKHALF);
-  golo(_ps2clk);
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
+  	// parity bit
+  	if (parity) gohi(_ps2data);
+	else golo(_ps2data);
 
-  delayMicroseconds(BYTEWAIT);
+	delayMicroseconds(CLKHALF);
+	golo(_ps2clk);
+	delayMicroseconds(CLKFULL);
+	gohi(_ps2clk);
+	delayMicroseconds(CLKHALF);
+
+	// stop bit
+	gohi(_ps2data);
+	delayMicroseconds(CLKHALF);
+	golo(_ps2clk);
+	delayMicroseconds(CLKFULL);
+	gohi(_ps2clk);
+	delayMicroseconds(CLKHALF);
+
+	delayMicroseconds(BYTEWAIT);
 
 #ifdef _PS2DBG
-  _PS2DBG.print(F("sent "));
-  _PS2DBG.println(data,HEX);
+	_PS2DBG.print(F("sent "));
+	_PS2DBG.println(data,HEX);
 #endif
 
-  return 0;
+	return 0;
 }
 
-int PS2dev::available() {
-  //delayMicroseconds(BYTEWAIT);
-  //return ( (digitalRead(_ps2data) == LOW) || (digitalRead(_ps2clk) == LOW) );
-  return ( (digitalRead(_ps2clk) == LOW) );
+int PS2dev::available()
+{
+	return digitalRead(_ps2clk) == LOW;
 }
 
 int PS2dev::read(unsigned char * value)
 {
-  unsigned int data = 0x00;
-  unsigned int bit = 0x01;
+	unsigned int data = 0x00;
+	unsigned int bit = 0x01;
 
-  unsigned char calculated_parity = 1;
-  unsigned char received_parity = 0;
+	unsigned char calculated_parity = 1;
+	unsigned char received_parity = 0;
 
-  //wait for data line to go low and clock line to go high (or timeout)
-  unsigned long waiting_since = millis();
-  while((digitalRead(_ps2data) != LOW) || (digitalRead(_ps2clk) != HIGH)) {
-    if((millis() - waiting_since) > TIMEOUT) return -1;
-  }
+	//wait for data line to go low and clock line to go high (or timeout)
+	unsigned long waiting_since = millis();
 
-  delayMicroseconds(CLKHALF);
-  golo(_ps2clk);
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
+	while ((digitalRead(_ps2data) != LOW) || (digitalRead(_ps2clk) != HIGH)) if ((millis() - waiting_since) > TIMEOUT) return -1;
 
-  while (bit < 0x0100) {
-    if (digitalRead(_ps2data) == HIGH)
-      {
-        data = data | bit;
-        calculated_parity = calculated_parity ^ 1;
-      } else {
-        calculated_parity = calculated_parity ^ 0;
-      }
+	delayMicroseconds(CLKHALF);
+	golo(_ps2clk);
+	delayMicroseconds(CLKFULL);
+	gohi(_ps2clk);
+	delayMicroseconds(CLKHALF);
 
-    bit = bit << 1;
+	while (bit < 0x0100)
+	{
+    	if (digitalRead(_ps2data) == HIGH)
+      	{
+        	data = data | bit;
+        	calculated_parity = calculated_parity ^ 1;
+      	} 
+		else
+		{
+        	calculated_parity = calculated_parity ^ 0;
+      	}
 
-    delayMicroseconds(CLKHALF);
-    golo(_ps2clk);
-    delayMicroseconds(CLKFULL);
-    gohi(_ps2clk);
-    delayMicroseconds(CLKHALF);
+    	bit = bit << 1;
 
-  }
-  // we do the delay at the end of the loop, so at this point we have
-  // already done the delay for the parity bit
+    	delayMicroseconds(CLKHALF);
+    	golo(_ps2clk);
+    	delayMicroseconds(CLKFULL);
+    	gohi(_ps2clk);
+    	delayMicroseconds(CLKHALF);
 
-  // parity bit
-  if (digitalRead(_ps2data) == HIGH)
-    {
-      received_parity = 1;
-    }
+	}
 
-  // stop bit
-  delayMicroseconds(CLKHALF);
-  golo(_ps2clk);
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
+  	// we do the delay at the end of the loop, so at this point we have
+	// already done the delay for the parity bit
 
+  	// parity bit
+  	if (digitalRead(_ps2data) == HIGH) received_parity = 1;
 
-  delayMicroseconds(CLKHALF);
-  golo(_ps2data);
-  golo(_ps2clk);
-  delayMicroseconds(CLKFULL);
-  gohi(_ps2clk);
-  delayMicroseconds(CLKHALF);
-  gohi(_ps2data);
+  	// stop bit
+  	delayMicroseconds(CLKHALF);
+  	golo(_ps2clk);
+  	delayMicroseconds(CLKFULL);
+  	gohi(_ps2clk);
+  	delayMicroseconds(CLKHALF);
 
+  	delayMicroseconds(CLKHALF);
+  	golo(_ps2data);
+  	golo(_ps2clk);
+  	delayMicroseconds(CLKFULL);
+  	gohi(_ps2clk);
+  	delayMicroseconds(CLKHALF);
+  	gohi(_ps2data);
 
-  *value = data & 0x00FF;
+	*value = data & 0x00FF;
 
 #ifdef _PS2DBG
-  _PS2DBG.print(F("received data "));
-  _PS2DBG.println(*value,HEX);
-  _PS2DBG.print(F("received parity "));
-  _PS2DBG.print(received_parity,BIN);
-  _PS2DBG.print(F(" calculated parity "));
-  _PS2DBG.println(received_parity,BIN);
+	_PS2DBG.print(F("received data "));
+	_PS2DBG.println(*value, HEX);
+	_PS2DBG.print(F("received parity "));
+	_PS2DBG.print(received_parity, BIN);
+	_PS2DBG.print(F(" calculated parity "));
+	_PS2DBG.println(received_parity, BIN);
 #endif
-  if (received_parity == calculated_parity) {
-    return 0;
-  } else {
-    return -2;
-  }
 
+	return received_parity == calculated_parity ? 0 : -2;
 }
 
 
 void PS2dev::keyboard_init()
 {
-  while(write(0xAA)!=0);
-  delay(10);
-  return;
+	while (write(0xAA) != 0) ;
+	delay(10);
+	return;
 }
 
 void PS2dev::ack()
 {
-  while(write(0xFA));
-  return;
+	while (write(0xFA)) ;
+  	return;
 }
 
 int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
 {
-  unsigned char val;
-  unsigned char enabled;
-  switch (cmd)
-  {
-  case 0xFF: //reset
-    ack();
-    //the while loop lets us wait for the host to be ready
-    while(write(0xAA)!=0);
-    break;
-  case 0xFE: //resend
-    ack();
-    break;
-  case 0xF6: //set defaults
-    //enter stream mode
-    ack();
-    break;
-  case 0xF5: //disable data reporting
-    //FM
-    enabled = 0;
-    ack();
-    break;
-  case 0xF4: //enable data reporting
-    //FM
-    enabled = 1;
-    ack();
-    break;
-  case 0xF3: //set typematic rate
-    ack();
-    if(!read(&val)) ack(); //do nothing with the rate
-    break;
-  case 0xF2: //get device id
-    ack();
-    write(0xAB);
-    write(0x83);
-    break;
-  case 0xF0: //set scan code set
-    ack();
-    if(!read(&val)) ack(); //do nothing with the rate
-    break;
-  case 0xEE: //echo
-    //ack();
-    write(0xEE);
-    break;
-  case 0xED: //set/reset LEDs
-    ack();
-    if(!read(leds)) ack(); //do nothing with the rate
+	unsigned char val;
+	unsigned char enabled;
+	switch (cmd)
+  	{
+  		case 0xFF: //reset
+    		ack();
+
+    		//the while loop lets us wait for the host to be ready
+    		while (write(0xAA) != 0) ;
+    		break;
+  		case 0xFE: //resend
+    		ack();
+    		break;
+  		case 0xF6: //set defaults
+    		//enter stream mode
+    		ack();
+    		break;
+  		case 0xF5: //disable data reporting
+    		//FM
+    		enabled = 0;
+    		ack();
+    		break;
+  		case 0xF4: //enable data reporting
+    		//FM
+    		enabled = 1;
+    		ack();
+    		break;
+  		case 0xF3: //set typematic rate
+    		ack();
+    		if (!read(&val)) ack(); //do nothing with the rate
+    		break;
+  		case 0xF2: //get device id
+    		ack();
+    		write(0xAB);
+    		write(0x83);
+    		break;
+  		case 0xF0: //set scan code set
+    		ack();
+    		if (!read(&val)) ack(); //do nothing with the rate
+    		break;
+  		case 0xEE: //echo
+    		write(0xEE);
+    		break;
+  		case 0xED: //set/reset LEDs
+    		ack();
+    		if (!read(leds)) ack(); //do nothing with the rate
 #ifdef _PS2DBG
-    _PS2DBG.print("LEDs: ");
-    _PS2DBG.println(*leds, HEX);
-    //digitalWrite(LED_BUILTIN, *leds);
+    		_PS2DBG.print("LEDs: ");
+    		_PS2DBG.println(*leds, HEX);
 #endif
-    return 1;
-    break;
-  }
-  return 0;
+    		return 1;
+  	}
+	  
+  	return 0;
 }
 
-int PS2dev::keyboard_handle(unsigned char *leds) {
-  unsigned char c;  //char stores data recieved from computer for KBD
-  if(available())
-  {
-    if(!read(&c)) return keyboard_reply(c, leds);
-  }
-  return 0;
+int PS2dev::keyboard_handle(unsigned char *leds)
+{
+	unsigned char c;  //char stores data recieved from computer for KBD
+
+  	if(available() && !read(&c)) return keyboard_reply(c, leds);
+
+  	return 0;
 }
 
 int PS2dev::keyboard_mkbrk(unsigned char code)
 {
-  write(code);
-  write(0xF0);
-  write(code);
-  return 0;
+	write(code);
+	write(0xF0);
+	write(code);
+	
+	return 0;
 }

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -41,21 +41,18 @@ PS2dev::PS2dev(int clk, int data)
 }
 
 /*
- * according to some code I saw, these functions will
- * correctly set the clock and data pins for
- * various conditions.  It's done this way so you don't need
- * pullup resistors.
+ * These functions set the state of internal pull-up resistors
  */
 void PS2dev::gohi(int pin)
 {
-	pinMode(pin, INPUT);
-	digitalWrite(pin, HIGH);
+	DDRB &= ~(1 << pin); // pinMode(pin, INPUT);
+	PORTB |= (1 << pin); // digitalWrite(pin, HIGH);
 }
 
 void PS2dev::golo(int pin)
 {
-	digitalWrite(pin, LOW);
-	pinMode(pin, OUTPUT);
+	PORTB &= ~(1 << pin); // digitalWrite(pin, INPUT);
+	DDRB |= (1 << pin); // pinMode(pin, OUTPUT);
 }
 
 int PS2dev::write(unsigned char data)
@@ -281,7 +278,7 @@ int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
 
 int PS2dev::keyboard_handle(unsigned char *leds)
 {
-	unsigned char c;  //char stores data recieved from computer for KBD
+	unsigned char c;  //char stores data recieved from computer for keyboard
 
   	if(available() && !read(&c)) return keyboard_reply(c, leds);
 
@@ -293,6 +290,6 @@ int PS2dev::keyboard_mkbrk(unsigned char code)
 	write(code);
 	write(0xF0);
 	write(code);
-	
+
 	return 0;
 }

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -64,7 +64,7 @@ int PS2dev::write(unsigned char data)
 
 #ifdef _PS2DBG
 	_PS2DBG.print(F("sending "));
-	_PS2DBG.println(data,HEX);
+	_PS2DBG.println(data, HEX);
 #endif
 
 	if (digitalRead(_ps2clk) == LOW) return -1;
@@ -117,7 +117,7 @@ int PS2dev::write(unsigned char data)
 
 #ifdef _PS2DBG
 	_PS2DBG.print(F("sent "));
-	_PS2DBG.println(data,HEX);
+	_PS2DBG.println(data, HEX);
 #endif
 
 	return 0;
@@ -285,7 +285,7 @@ int PS2dev::keyboard_handle(unsigned char *leds)
   	return 0;
 }
 
-int PS2dev::keyboard_mkbrk(unsigned char code)
+int PS2dev::keyboard_mkbrk(unsigned char code) // This function doesn't work with the modifyer keys (Escape, Space, Shift, etc.)
 {
 	write(code);
 	write(0xF0);

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -372,6 +372,16 @@ int PS2dev::keyboard_release_printscreen()
 	return r;
 }
 
+int PS2dev::keyboard_mkbrk_printscreen()
+{
+	int r;
+
+	r = keyboard_pres_printscreen();
+	r += keyboard_release_printscreen();
+
+	return r;
+}
+
 int PS2dev::keyboard_pausebreak()
 {
 	int r;

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -208,16 +208,13 @@ int PS2dev::read(unsigned char * value)
 void PS2dev::keyboard_init()
 {
 	while (write(0xAA) != 0) ;
-	delay(10);
 
-	return;
+	delay(10);
 }
 
 void PS2dev::ack()
 {
 	while (write(0xFA)) ;
-
-  	return;
 }
 
 int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
@@ -344,6 +341,48 @@ int PS2dev::keyboard_special_mkbrk(unsigned char code)
 	r += write(0xe0);
 	r += write(0xf0);
 	r += write(code);
+
+	return r;
+}
+
+int PS2dev::keyboard_press_printscreen()
+{
+	int r;
+
+	r = write(0xe0);
+	r += write(0x12);
+	r += write(0xe0);
+	r += write(0x7c);
+
+	return r;
+}
+
+int PS2dev::keyboard_release_printscreen()
+{
+	int r;
+
+	r = write(0xe0);
+	r += write(0xf0);
+	r += write(0x7c);
+	r += write(0xe0);
+	r += write(0xf0);
+	r += write(0x12);
+
+	return r;
+}
+
+int PS2dev::keyboard_pausebreak()
+{
+	int r;
+
+	r = write(0xe1);
+	r += write(0x14);
+	r += write(0x77);
+	r += write(0xe1);
+	r += write(0xf0);
+	r += write(0x14);
+	r += write(0xe0);
+	r += write(0x77);
 
 	return r;
 }

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -286,11 +286,13 @@ int PS2dev::keyboard_handle(unsigned char *leds)
   	return 0;
 }
 
+// Presses one of the non-special characters
 int PS2dev::keyboard_press(unsigned char code)
 {
 	return write(code);
 }
 
+// Releases one of the non-special characters
 int PS2dev::keyboard_release(unsigned char code)
 {
 	int r;
@@ -301,6 +303,7 @@ int PS2dev::keyboard_release(unsigned char code)
 	return r;
 }
 
+// Presses one of the special characters
 int PS2dev::keyboard_press_special(unsigned char code)
 {
 	int r;
@@ -311,6 +314,7 @@ int PS2dev::keyboard_press_special(unsigned char code)
 	return r;
 }
 
+// Releases one of the special characters
 int PS2dev::keyboard_release_special(unsigned char code)
 {
 	int r;
@@ -322,6 +326,7 @@ int PS2dev::keyboard_release_special(unsigned char code)
 	return r;
 }
 
+// Presses then releases one of the non-special characters
 int PS2dev::keyboard_mkbrk(unsigned char code)
 {
 	int r;
@@ -333,6 +338,7 @@ int PS2dev::keyboard_mkbrk(unsigned char code)
 	return r;
 }
 
+// Presses then releases one of the special characters
 int PS2dev::keyboard_special_mkbrk(unsigned char code)
 {
 	int r;
@@ -346,6 +352,7 @@ int PS2dev::keyboard_special_mkbrk(unsigned char code)
 	return r;
 }
 
+// Presses Printscreen
 int PS2dev::keyboard_press_printscreen()
 {
 	int r;
@@ -358,6 +365,7 @@ int PS2dev::keyboard_press_printscreen()
 	return r;
 }
 
+// Releases Printscreen
 int PS2dev::keyboard_release_printscreen()
 {
 	int r;
@@ -372,6 +380,7 @@ int PS2dev::keyboard_release_printscreen()
 	return r;
 }
 
+// Presses then releases Printscreen
 int PS2dev::keyboard_mkbrk_printscreen()
 {
 	int r;
@@ -382,6 +391,7 @@ int PS2dev::keyboard_mkbrk_printscreen()
 	return r;
 }
 
+// Presses/Releases Pause/Break
 int PS2dev::keyboard_pausebreak()
 {
 	int r;

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -229,6 +229,7 @@ int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
 
     		//the while loop lets us wait for the host to be ready
     		while (write(0xAA) != 0) ;
+			
     		break;
   		case 0xFE: //resend
     		ack();

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -216,6 +216,7 @@ void PS2dev::keyboard_init()
 void PS2dev::ack()
 {
 	while (write(0xFA)) ;
+
   	return;
 }
 
@@ -223,6 +224,7 @@ int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
 {
 	unsigned char val;
 	unsigned char enabled;
+
 	switch (cmd)
   	{
   		case 0xFF: //reset
@@ -281,16 +283,67 @@ int PS2dev::keyboard_handle(unsigned char *leds)
 {
 	unsigned char c;  //char stores data recieved from computer for keyboard
 
-  	if(available() && !read(&c)) return keyboard_reply(c, leds);
+  	if (available() && !read(&c)) return keyboard_reply(c, leds);
 
   	return 0;
 }
 
-int PS2dev::keyboard_mkbrk(unsigned char code) // This function doesn't work with the modifyer keys (Escape, Space, Shift, etc.)
+int PS2dev::keyboard_press(unsigned char code)
 {
-	write(code);
-	write(0xF0);
-	write(code);
+	return write(code);
+}
 
-	return 0;
+int PS2dev::keyboard_release(unsigned char code)
+{
+	int r;
+
+	r = write(0xf0);
+	r += write(code);
+
+	return r;
+}
+
+int PS2dev::keyboard_press_special(unsigned char code)
+{
+	int r;
+
+	r = write(0xe0);
+	r += write(code);
+
+	return r;
+}
+
+int PS2dev::keyboard_release_special(unsigned char code)
+{
+	int r;
+
+	r = write(0xe0);
+	r += write(0xf0);
+	r += write(code);
+
+	return r;
+}
+
+int PS2dev::keyboard_mkbrk(unsigned char code)
+{
+	int r;
+
+	r = write(code);
+	r += write(0xf0);
+	r += write(code);
+
+	return r;
+}
+
+int PS2dev::keyboard_special_mkbrk(unsigned char code)
+{
+	int r;
+
+	r = write(0xe0);
+	r += write(code);
+	r += write(0xe0);
+	r += write(0xf0);
+	r += write(code);
+
+	return r;
 }

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -209,6 +209,7 @@ void PS2dev::keyboard_init()
 {
 	while (write(0xAA) != 0) ;
 	delay(10);
+
 	return;
 }
 

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -89,15 +89,56 @@ class PS2dev
 			SLASH = 4a,
 			RIGHT_SHIFT = 0x59,
 			LEFT_CONTROL = 0x14,
+			LEFT_ALT = 0x11,
+			SPACE = 0x29,
+			NUM_LOCK = 0x77,
+			ASTERISK = 0x7c,
+			NUMPAD_MINUS = 0x7b,
+			NUMPAD_SEVEN = 0x6c,
+			NUMPAD_EIGHT = 0x75,
+			NUMPAD_NINE = 0x7d,
+			PLUS = 0x79,
+			NUMPAD_FOUR = 0x6b,
+			NUMPAD_FIVE = 0x73,
+			NUMPAD_SIX = 0x74,
+			NUMPAD_ONE = 0x69,
+			NUMPAD_TWO = 0x72,
+			NUMPAD_THREE = 0x7a,
+			NUMPAD_ZERO = 0x70,
+			DECIMAL = 0x71
+		};
+
+		// All press transmissions using these are preceded with 0xe0
+		// All release transmissions using these are preceded with 0xe0, 0xf0
+		enum SpecialScanCodes
+		{
+			LEFT_WIN = 0x1f,
+			RIGHT_ALT = 0x11,
+			RIGHT_WIN = 0x27,
+			MENUS = 0x2f,
+			RIGHT_CONTROL = 0x14,
+			INSERT = 0x70,
+			HOME = 0x6c,
+			PAGE_UP = 0x7d,
+			DELETE = 0x71,
+			END = 0x69,
+			PAGE_DOWN = 0x7a,
+			UP_ARROW = 0x75,
+			LEFT_ARROW = 0x6b,
+			DOWN_ARROW = 0x72,
+			RIGHT_ARROW = 0x74,
+			DIVIDE = 0x4a,
+			NUMPAD_ENTER = 0x5a
 		};
 
 		int write(unsigned char data);
-		int read(unsigned char * data);
+		int read(unsigned char *data);
 		int available();
 		void keyboard_init();
 		int keyboard_reply(unsigned char cmd, unsigned char *leds);
 		int keyboard_handle(unsigned char *leds);
 		int keyboard_mkbrk(unsigned char code);
+
 	private:
 		int _ps2clk;
 		int _ps2data;
@@ -107,4 +148,3 @@ class PS2dev
 };
 
 #endif /* ps2dev_h */
-

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -1,8 +1,10 @@
 /*
  * ps2dev.h - a library to interface with ps2 hosts. See comments in
- * ps2.cpp.
+ * ps2dev.cpp.
  * Written by Chris J. Kiick, January 2008.
  * modified by Gene E. Scogin, August 2008.
+ * modified by Tomas 'Harvie' Mudrunka 2019.
+ * modified once more by Iggy Glassman 2020.
  * Release into public domain.
  */
 
@@ -16,6 +18,79 @@ class PS2dev
 {
 	public:
 		PS2dev(int clk, int data);
+
+		enum ScanCodes // Print Screen and Pause/Break are multiple sequences
+		{
+			ESCAPE = 0x76,
+			F1 = 0x05,
+			F2 = 0x06,
+			F3 = 0x04,
+			F4 = 0x0c,
+			F5 = 0x03,
+			F6 = 0x0b,
+			F7 = 0x83,
+			F8 = 0x0a,
+			F9 = 0x01,
+			F10 = 0x09,
+			F11 = 0x78,
+			F12 = 0x07,
+			SCROLL_LOCK = 0x7e,
+			ACCENT = 0x0e,
+			ONE = 0x16,
+			TWO = 0x1e,
+			THREE = 0x26,
+			FOUR = 0x25,
+			FIVE = 0x2e,
+			SIX = 0x36,
+			SEVEN = 0x3d,
+			EIGHT = 0x3e,
+			NINE = 0x46,
+			ZERO = 0x45,
+			MINUS = 0x4e,
+			EQUAL = 0x55,
+			BACKSPACE = 0x66,
+			TAB = 0x0d,
+			Q = 0x15,
+			W = 0x1d,
+			E = 0x24,
+			R = 2d,
+			T = 0x2c,
+			Y = 0x35,
+			U = 0x3c,
+			I = 0x43,
+			O = 0x44,
+			P = 0x4d,
+			OPEN_BRACKET = 0x54,
+			CLOSE_BRACKET = 0x5b,
+			BACKSLASH = 0x5d,
+			CAPS_LOCK = 0x58,
+			A = 0x1c,
+			S = 0x1b,
+			D = 0x23,
+			F = 0x2b,
+			G = 0x34,
+			H = 0x33,
+			J = 0x3b,
+			K = 0x42,
+			L = 0x4b,
+			SEMI_COLON = 0x4c,
+			TICK_MARK = 0x52,
+			ENTER = 0x5a,
+			LEFT_SHIFT = 0x12,
+			Z = 0x1a,
+			X = 0x22,
+			C = 0x21,
+			V = 0x2a,
+			B = 0x32,
+			N = 0x31,
+			M = 0x3a,
+			COMMA = 0x41,
+			PERIOD = 0x49,
+			SLASH = 4a,
+			RIGHT_SHIFT = 0x59,
+			LEFT_CONTROL = 0x14,
+		};
+
 		int write(unsigned char data);
 		int read(unsigned char * data);
 		int available();

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -10,6 +10,7 @@
 #define ps2dev_h
 
 #include "Arduino.h"
+#include <avr/io.h>
 
 class PS2dev
 {

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -19,6 +19,8 @@ class PS2dev
 	public:
 		PS2dev(int clk, int data);
 
+		// Enum containing all of the non-special keycodes/scancodes
+		// (if you can't find the scancode you're looking for here, check the special scancodes)
 		enum ScanCodes
 		{
 			ESCAPE = 0x76,
@@ -108,6 +110,7 @@ class PS2dev
 			DECIMAL = 0x71
 		};
 
+		// Enum containing all of the special keycodes/scancodes
 		// All press transmissions using these are preceded with 0xE0
 		// All release transmissions using these are preceded with 0xE0, 0xF0
 		enum SpecialScanCodes

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -159,6 +159,7 @@ class PS2dev
 		int keyboard_release_special(unsigned char code);
 		int keyboard_press_printscreen();
 		int keyboard_release_printscreen();
+		int keyboard_mkbrk_printscreen();
 		int keyboard_pausebreak();
 		int keyboard_reply(unsigned char cmd, unsigned char *leds);
 		int keyboard_handle(unsigned char *leds);

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -19,7 +19,7 @@ class PS2dev
 	public:
 		PS2dev(int clk, int data);
 
-		enum ScanCodes // Print Screen and Pause/Break are multiple sequences
+		enum ScanCodes
 		{
 			ESCAPE = 0x76,
 			F1 = 0x05,
@@ -108,8 +108,8 @@ class PS2dev
 			DECIMAL = 0x71
 		};
 
-		// All press transmissions using these are preceded with 0xe0
-		// All release transmissions using these are preceded with 0xe0, 0xf0
+		// All press transmissions using these are preceded with 0xE0
+		// All release transmissions using these are preceded with 0xE0, 0xF0
 		enum SpecialScanCodes
 		{
 			LEFT_WIN = 0x1f,
@@ -128,7 +128,25 @@ class PS2dev
 			DOWN_ARROW = 0x72,
 			RIGHT_ARROW = 0x74,
 			DIVIDE = 0x4a,
-			NUMPAD_ENTER = 0x5a
+			NUMPAD_ENTER = 0x5a,
+			NEXT_TRACK = 0x4d,
+			PREVIOUS_TRACK = 0x15,
+			STOP = 0x3b,
+			PLAY_PAUSE = 0x34,
+			MUTE = 0x23,
+			VOLUME_UP = 0x32,
+			VOLUME_DOWN = 0x21,
+			MEDIA_SELECT = 0x50,
+			EMAIL = 0x48,
+			CALCULATOR = 0x2b,
+			MY_COMPUTER = 0x40,
+			WWW_SEARCH = 0x10,
+			WWW_HOME = 0x3a,
+			WWW_BACK = 0x38,
+			WWW_FORWARD = 0x30,
+			WWW_STOP = 0x28,
+			WWW_REFRESH = 0x20,
+			WWW_FAVORITES = 0x18
 		};
 
 		int write(unsigned char data);

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -139,6 +139,9 @@ class PS2dev
 		int keyboard_release(unsigned char code);
 		int keyboard_press_special(unsigned char code);
 		int keyboard_release_special(unsigned char code);
+		int keyboard_press_printscreen();
+		int keyboard_release_printscreen();
+		int keyboard_pausebreak();
 		int keyboard_reply(unsigned char cmd, unsigned char *leds);
 		int keyboard_handle(unsigned char *leds);
 		int keyboard_mkbrk(unsigned char code);

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -135,9 +135,14 @@ class PS2dev
 		int read(unsigned char *data);
 		int available();
 		void keyboard_init();
+		int keyboard_press(unsigned char code);
+		int keyboard_release(unsigned char code);
+		int keyboard_press_special(unsigned char code);
+		int keyboard_release_special(unsigned char code);
 		int keyboard_reply(unsigned char cmd, unsigned char *leds);
 		int keyboard_handle(unsigned char *leds);
 		int keyboard_mkbrk(unsigned char code);
+		int keyboard_special_mkbrk(unsigned char code);
 
 	private:
 		int _ps2clk;


### PR DESCRIPTION
I added two enums (and some functions to go along with them) containing PS2 scancodes.

One of the enums contains the "non-special" characters (escape, tab, alphabet, etc.), while the other contains the special characters prefixed by `0xE0`.