### PR TITLE
Implement I/O abort for read()/write().

### DIFF
--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -38,6 +38,7 @@ PS2dev::PS2dev(int clk, int data)
   _ps2data = data;
   gohi(_ps2clk);
   gohi(_ps2data);
+  ridx = widx = 0;
 }
 
 /*
@@ -64,6 +65,31 @@ int PS2dev::write(unsigned char data)
 {
   delayMicroseconds(BYTEWAIT);
 
+  do {
+    bool need_wait = false;
+    while (raw_available()) {
+      unsigned char c;
+      if (raw_read(&c) == 0) {
+        int widx_next = widx + 1;
+        if (widx_next == RABUF_LEN) widx_next = 0;
+        if (widx_next == ridx) {
+          /* Overflow. Discarding read data. */
+        } else {
+          /* Store read data into read ahead buffer */
+          rabuf[widx] = c;
+          widx = widx_next;
+        }
+        need_wait = true;
+      }
+    }
+    if (need_wait) delayMicroseconds(BYTEWAIT);
+  } while (raw_write(data) != 0);
+
+  return 0;
+}
+
+int PS2dev::raw_write(unsigned char data)
+{
   unsigned char i;
   unsigned char parity = 1;
 
@@ -71,14 +97,6 @@ int PS2dev::write(unsigned char data)
   _PS2DBG.print(F("sending "));
   _PS2DBG.println(data,HEX);
 #endif
-
-  if (digitalRead(_ps2clk) == LOW) {
-    return -1;
-  }
-
-  if (digitalRead(_ps2data) == LOW) {
-    return -2;
-  }
 
   golo(_ps2data);
   delayMicroseconds(CLKHALF);
@@ -90,6 +108,11 @@ int PS2dev::write(unsigned char data)
 
   for (i=0; i < 8; i++)
     {
+      if (digitalRead(_ps2clk) == LOW) { /* I/O request from host */
+        /* Abort */
+        gohi(_ps2data);
+        return -1;
+      }
       if (data & 0x01)
       {
         gohi(_ps2data);
@@ -136,12 +159,34 @@ int PS2dev::write(unsigned char data)
   return 0;
 }
 
+int
+PS2dev::racnt()
+{
+  int cnt = widx - ridx;
+  if (cnt < 0) cnt += RABUF_LEN;
+  return cnt;
+}
+
 int PS2dev::available() {
+  return (racnt() > 0 || raw_available());
+}
+
+int PS2dev::raw_available() {
   //delayMicroseconds(BYTEWAIT);
   return ( (digitalRead(_ps2data) == LOW) || (digitalRead(_ps2clk) == LOW) );
 }
 
 int PS2dev::read(unsigned char * value)
+{
+  if (racnt() > 0) { /* Try to read from read ahead buffer first. */
+    *value = rabuf[ridx++];
+    if (ridx == RABUF_LEN) ridx = 0;
+    return 0;
+  }
+  return raw_read(value);
+}
+
+int PS2dev::raw_read(unsigned char * value)
 {
   unsigned int data = 0x00;
   unsigned int bit = 0x01;
@@ -152,6 +197,7 @@ int PS2dev::read(unsigned char * value)
   //wait for data line to go low and clock line to go high (or timeout)
   unsigned long waiting_since = millis();
   while((digitalRead(_ps2data) != LOW) || (digitalRead(_ps2clk) != HIGH)) {
+    if (!raw_available()) return -2; /* Cancelled */
     if((millis() - waiting_since) > TIMEOUT) return -1;
   }
 

--- a/src/ps2dev.cpp
+++ b/src/ps2dev.cpp
@@ -334,9 +334,9 @@ int PS2dev::keyboard_reply(unsigned char cmd, unsigned char *leds)
     break;
   case 0xED: //set/reset LEDs
     //ack();
-    while (write(0xAF) != 0) delay(1);
+    while (write(0xFA) != 0) delay(1);
     if(!read(leds)) {
-       while (write(0xAF) != 0) delay(1);
+       while (write(0xFA) != 0) delay(1);
     } 
 #ifdef _PS2DBG
     _PS2DBG.print("LEDs: ");

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -11,6 +11,8 @@
 
 #include "Arduino.h"
 
+#define RABUF_LEN 16
+
 class PS2dev
 {
 	public:
@@ -174,6 +176,13 @@ class PS2dev
 		void golo(int pin);
 		void gohi(int pin);
 		void ack();
+		int raw_write(unsigned char data);
+		int raw_read(unsigned char *data);
+		int raw_available();
+		int racnt();
+		unsigned char rabuf[RABUF_LEN]; /* Read ahead buffer */
+		int ridx;
+		int widx;
 };
 
 #endif /* ps2dev_h */

--- a/src/ps2dev.h
+++ b/src/ps2dev.h
@@ -11,8 +11,6 @@
 
 #include "Arduino.h"
 
-#define RABUF_LEN 16
-
 class PS2dev
 {
 	public:
@@ -154,6 +152,14 @@ class PS2dev
 			WAKE = 0x63
 		};
 
+		enum ErrorCodes
+		{
+			EABORT = -3,
+			ECANCEL = -2,
+			ETIMEOUT = -1,
+			ENOERR = 0
+		};
+
 		int write(unsigned char data);
 		int read(unsigned char * data);
 		int available();
@@ -176,13 +182,10 @@ class PS2dev
 		void golo(int pin);
 		void gohi(int pin);
 		void ack();
-		int raw_write(unsigned char data);
-		int raw_read(unsigned char *data);
-		int raw_available();
-		int racnt();
-		unsigned char rabuf[RABUF_LEN]; /* Read ahead buffer */
-		int ridx;
-		int widx;
+		int do_write(unsigned char data);
+		int do_read(unsigned char *data);
+		bool handling_io_abort;
+		unsigned char leds;
 };
 
 #endif /* ps2dev_h */


### PR DESCRIPTION
First, I would like to appriciate the authors of this excellent library.
I have used this library to perform keyboard inputs automatically to Hewlett Packard spectrum analyzer (HP8590E series). I noticed the issue that sometimes the library hangs or the equipment receives garbage data during transfering the data. I looked into this problem and found the issue causes when the equipment pulls the clock line down while write() is performed. I confirmed that this patch fixes the issue.

Please consider merging this pull request to the repository.

Thanks in advance.